### PR TITLE
Centralize all instruction information

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,6 +12,7 @@ set(SOURCE_FILES
   mu/Mutext/Parser.cpp
   mu/Mutext/StringUtils.cpp
   mu/Argument.cpp
+  mu/Bytecode.cpp
   mu/Loader.cpp
   mu/Log.cpp
   mu/InstructionProcessor.cpp

--- a/input.mut
+++ b/input.mut
@@ -1,3 +1,3 @@
-push i32:5
-push i32:6
-add
+Push i32:5
+Push i32:6
+Add

--- a/main.cpp
+++ b/main.cpp
@@ -4,6 +4,7 @@
 #include <fmt/core.h>
 using fmt::print;
 
+#include "mu/Bytecode.hpp"
 #include "mu/InstructionProcessor.hpp"
 #include "mu/Loader.hpp"
 #include "mu/Mutext/Parser.hpp"
@@ -21,6 +22,7 @@ bool AreEqual(const char* left, const char* right);
 bool IsMutextFile(const char* filePath);
 
 int main(int argc, char** argv) {
+  InitializeInstructions();
   if (argc != 2 || AreEqual(argv[1], "--help")) {
     return PrintHelp();
   } else if (AreEqual(argv[1], "--test")) {

--- a/mu/Bytecode.cpp
+++ b/mu/Bytecode.cpp
@@ -1,0 +1,68 @@
+#include <doctest.h>
+
+#include <unordered_map>
+using std::unordered_map;
+
+#include "Bytecode.hpp"
+
+#include "Interpreter/Add.hpp"
+#include "Interpreter/Subtract.hpp"
+
+static unordered_map<OpCode, InstructionMetadata> Instructions;
+
+void InitializeInstructions() {
+  RegisterInstruction(OpCode::Add, GetAddMetadata());
+  RegisterInstruction(OpCode::Subtract, GetSubtractMetadata());
+}
+
+void RegisterInstruction(OpCode opCode, InstructionMetadata metadata) {
+  Instructions[opCode] = metadata;
+}
+
+bool HasInstruction(OpCode opCode) { return Instructions.contains(opCode); }
+
+OpCode GetOpCode(string name) {
+  for (auto& [opCode, metadata] : Instructions) {
+    if (metadata.name == name) {
+      return opCode;
+    }
+  }
+
+  return OpCode::Nop;
+}
+
+void ExecuteInstruction(OpCode opCode) { Instructions[opCode].execute(); }
+
+string GetInstructionName(OpCode opCode) { return Instructions[opCode].name; }
+
+bool operator==(Instruction left, Instruction right) {
+  return left.opCode == right.opCode && left.argument == right.argument;
+}
+
+bool MockInstructionCalled = false;
+void MockInstruction() { MockInstructionCalled = true; }
+InstructionMetadata MockInstructionMetadata = {.execute = MockInstruction,
+                                               .name = "MockInstruction"};
+
+TEST_CASE("Verify instruction registration behavior") {
+  SUBCASE("Verify that instructions can be executed") {
+    RegisterInstruction(OpCode::Nop, MockInstructionMetadata);
+    ExecuteInstruction(OpCode::Nop);
+    CHECK(MockInstructionCalled);
+  }
+
+  SUBCASE("Verify that instructions namecan be retrieved") {
+    RegisterInstruction(OpCode::Nop, MockInstructionMetadata);
+    CHECK(GetInstructionName(OpCode::Nop) == "MockInstruction");
+  }
+
+  SUBCASE("Verify that instructions can be checked for existence") {
+    RegisterInstruction(OpCode::Nop, MockInstructionMetadata);
+    CHECK(HasInstruction(OpCode::Nop));
+  }
+
+  SUBCASE("Verify that instructions can be retrieved by name") {
+    RegisterInstruction(OpCode::Nop, MockInstructionMetadata);
+    CHECK(GetOpCode("MockInstruction") == OpCode::Nop);
+  }
+}

--- a/mu/Bytecode.hpp
+++ b/mu/Bytecode.hpp
@@ -2,6 +2,9 @@
 
 #include <cstdint>
 
+#include <string>
+using std::string;
+
 #include <fmt/format.h>
 
 #include "Argument.hpp"
@@ -32,31 +35,37 @@ struct Instruction {
   Argument argument;
 };
 
-inline bool operator==(Instruction left, Instruction right) {
-  return left.opCode == right.opCode && left.argument == right.argument;
-}
+typedef void (*ExecuteInstructionFunc)();
+
+struct InstructionMetadata {
+  ExecuteInstructionFunc execute;
+  string name;
+};
+
+void InitializeInstructions();
+
+void RegisterInstruction(OpCode opCode, InstructionMetadata metadata);
+bool HasInstruction(OpCode opCode);
+OpCode GetOpCode(string name);
+void ExecuteInstruction(OpCode opCode);
+string GetInstructionName(OpCode opCode);
+
+bool operator==(Instruction left, Instruction right);
 
 template <> struct fmt::formatter<OpCode> : formatter<string_view> {
   // parse is inherited from formatter<string_view>.
-  template <typename FormatContext> auto format(OpCode c, FormatContext& ctx) {
+  template <typename FormatContext>
+  auto format(OpCode opCode, FormatContext& ctx) {
     string_view name = "unknown";
-    switch (c) {
-    case OpCode::Nop:
+    if (opCode == OpCode::Nop)
       name = "Nop";
-      break;
-    case OpCode::Push:
+    else if (opCode == OpCode::Push)
       name = "Push";
-      break;
-    case OpCode::Pop:
+    else if (opCode == OpCode::Pop)
       name = "Pop";
-      break;
-    case OpCode::Add:
-      name = "Add";
-      break;
-    case OpCode::Subtract:
-      name = "Subtract";
-      break;
-    }
+    else if (HasInstruction(opCode))
+      name = GetInstructionName(opCode);
+
     return formatter<string_view>::format(name, ctx);
   }
 };

--- a/mu/InstructionProcessor.cpp
+++ b/mu/InstructionProcessor.cpp
@@ -22,10 +22,8 @@ void Process(span<Instruction> instructions) {
       Push(ins.argument);
     else if (ins.opCode == OpCode::Pop)
       Pop();
-    else if (ins.opCode == OpCode::Add)
-      Add();
-    else if (ins.opCode == OpCode::Subtract)
-      Subtract();
+    else if (HasInstruction(ins.opCode))
+      ExecuteInstruction(ins.opCode);
     else
       throw logic_error(format("Unexpected opcode: {}", (int)ins.opCode));
   }

--- a/mu/Interpreter/Add.cpp
+++ b/mu/Interpreter/Add.cpp
@@ -3,6 +3,7 @@
 #include <limits>
 using std::numeric_limits;
 
+#include "Bytecode.hpp"
 #include "Interpreter/Add.hpp"
 #include "Interpreter/BinaryArithmeticOperation.hpp"
 #include "ValueStack.hpp"
@@ -10,6 +11,8 @@ using std::numeric_limits;
 void Add() {
   PerformBinaryOperation([](auto left, auto right) { return left + right; });
 }
+
+InstructionMetadata GetAddMetadata() { return {.execute = Add, .name = "Add"}; }
 
 TEST_CASE("Verify add opcode behavior") {
   SUBCASE("Verify add opcode behavior a 32-bit integer and a 32-bit integer") {

--- a/mu/Interpreter/Add.hpp
+++ b/mu/Interpreter/Add.hpp
@@ -1,3 +1,6 @@
 #pragma once
 
+#include "Bytecode.hpp"
+
 void Add();
+InstructionMetadata GetAddMetadata();

--- a/mu/Interpreter/Subtract.cpp
+++ b/mu/Interpreter/Subtract.cpp
@@ -11,6 +11,10 @@ void Subtract() {
   PerformBinaryOperation([](auto left, auto right) { return left - right; });
 }
 
+InstructionMetadata GetSubtractMetadata() {
+  return {.execute = Subtract, .name = "Subtract"};
+}
+
 TEST_CASE("Verify subtract opcode behavior") {
   SUBCASE("Verify subtract opcode behavior for a 32-bit integer and a 32-bit "
           "integer") {
@@ -100,8 +104,8 @@ TEST_CASE("Verify subtract opcode behavior") {
     CHECK(Pop().f64() == expected);
   }
 
-  SUBCASE(
-      "Verify subtract opcode behavior for a 32-bit float and a 32-bit float") {
+  SUBCASE("Verify subtract opcode behavior for a 32-bit float and a 32-bit "
+          "float") {
     const float left = 42;
     const float right = 43;
     const float expected = -1;
@@ -133,8 +137,8 @@ TEST_CASE("Verify subtract opcode behavior") {
     CHECK(Pop().f32() == expected);
   }
 
-  SUBCASE(
-      "Verify subtract opcode behavior for a 32-bit float and a 64-bit float") {
+  SUBCASE("Verify subtract opcode behavior for a 32-bit float and a 64-bit "
+          "float") {
     const float left = 42;
     const double right = 43;
     const double expected = -1;
@@ -144,8 +148,8 @@ TEST_CASE("Verify subtract opcode behavior") {
     CHECK(Pop().f64() == expected);
   }
 
-  SUBCASE(
-      "Verify subtract opcode behavior for a 64-bit float and a 64-bit float") {
+  SUBCASE("Verify subtract opcode behavior for a 64-bit float and a 64-bit "
+          "float") {
     const double left = 20;
     const double right = -15;
     const double expected = 35;
@@ -177,8 +181,8 @@ TEST_CASE("Verify subtract opcode behavior") {
     CHECK(Pop().f64() == expected);
   }
 
-  SUBCASE(
-      "Verify subtract opcode behavior for a 64-bit float and a 32-bit float") {
+  SUBCASE("Verify subtract opcode behavior for a 64-bit float and a 32-bit "
+          "float") {
     const double left = 20;
     const float right = -15;
     const double expected = 35;

--- a/mu/Interpreter/Subtract.hpp
+++ b/mu/Interpreter/Subtract.hpp
@@ -1,3 +1,4 @@
 #pragma once
 
 void Subtract();
+InstructionMetadata GetSubtractMetadata();

--- a/mu/Mutext/Parser.cpp
+++ b/mu/Mutext/Parser.cpp
@@ -9,6 +9,7 @@ using std::from_chars;
 #include <string>
 using std::string;
 
+#include "Bytecode.hpp"
 #include "Parser.hpp"
 #include "StringUtils.hpp"
 
@@ -29,7 +30,7 @@ TEST_CASE("Verify ParseMutextFile behavior") {
   }
 
   SUBCASE("Can parse multiple instructions from a file") {
-    TestFile testFile("test.mut", "pop\npush i32:42\n");
+    TestFile testFile("test.mut", "Pop\nPush i32:42\n");
     auto instructions = ParseMutextFile("test.mut");
     CHECK(instructions.size() == 2);
     CHECK(instructions[0].opCode == OpCode::Pop);
@@ -72,19 +73,19 @@ TEST_CASE("Verify Parse behavior") {
   }
 
   SUBCASE("Can parse a single instruction") {
-    auto instructions = Parse("pop\n");
+    auto instructions = Parse("Pop\n");
     CHECK(instructions.size() == 1);
     CHECK(instructions[0].opCode == OpCode::Pop);
   }
 
   SUBCASE("Can parse a single instruction with a parameter") {
-    auto instructions = Parse("add\n");
+    auto instructions = Parse("Add\n");
     CHECK(instructions.size() == 1);
     CHECK(instructions[0].opCode == OpCode::Add);
   }
 
-  SUBCASE("Can parse a single push instruction with a parameter") {
-    auto instructions = Parse("push i32:42\n");
+  SUBCASE("Can parse a single Push instruction with a parameter") {
+    auto instructions = Parse("Push i32:42\n");
     CHECK(instructions.size() == 1);
     CHECK(instructions[0].opCode == OpCode::Push);
     CHECK(instructions[0].argument.Type() == ArgumentType::i32);
@@ -92,7 +93,7 @@ TEST_CASE("Verify Parse behavior") {
   }
 
   SUBCASE("Can parse two instructions") {
-    auto instructions = Parse("pop\npush i32:42\n");
+    auto instructions = Parse("Pop\nPush i32:42\n");
     CHECK(instructions.size() == 2);
     CHECK(instructions[0].opCode == OpCode::Pop);
     CHECK(instructions[1].opCode == OpCode::Push);
@@ -142,33 +143,29 @@ static bool IsWhiteSpace(const string& line) {
 }
 
 static Instruction ParseLine(string line) {
-  if (line == "pop")
+  if (line == "Pop")
     return Instruction{OpCode::Pop};
-  else if (line.starts_with("push"))
+  else if (line.starts_with("Push"))
     return Instruction{OpCode::Push, ParseArgument(line)};
-  else if (line == "add")
-    return Instruction{OpCode::Add};
-  else if (line == "sub")
-    return Instruction{OpCode::Subtract};
-  else
-    return Instruction{OpCode::Nop};
+
+  return Instruction{GetOpCode(line)};
 }
 
 TEST_CASE("Verify ParseLine behavior") {
-  SUBCASE("Can parse a line to a pop instruction") {
-    auto instruction = ParseLine("pop");
+  SUBCASE("Can parse a line to a Pop instruction") {
+    auto instruction = ParseLine("Pop");
     CHECK(instruction.opCode == OpCode::Pop);
   }
 
-  SUBCASE("Can parse a line to a push instruction") {
-    auto instruction = ParseLine("push i32:4");
+  SUBCASE("Can parse a line to a Push instruction") {
+    auto instruction = ParseLine("Push i32:4");
     CHECK(instruction.opCode == OpCode::Push);
     CHECK(instruction.argument.Type() == ArgumentType::i32);
     CHECK(instruction.argument.i32() == 4);
   }
 
-  SUBCASE("Can parse a line to an add instruction") {
-    auto instruction = ParseLine("add");
+  SUBCASE("Can parse a line to an Add instruction") {
+    auto instruction = ParseLine("Add");
     CHECK(instruction.opCode == OpCode::Add);
   }
 }


### PR DESCRIPTION
Rather than leaving instructions spread out across multiple files, centralize instruction information to only a few place, to make it simpler to add instructions.

This is done with an `InstructionMetdata` type that all instructions must provide.