### PR TITLE
Add missing stack pop calls

### DIFF
--- a/mu/Interpreter/Add.cpp
+++ b/mu/Interpreter/Add.cpp
@@ -218,11 +218,13 @@ TEST_CASE("Verify add opcode performance") {
     Push(43);
     Push(42);
     Add();
+    Pop();
   });
 
   b.run("Add two floats", [] {
     Push(43.4);
     Push(42.7);
     Add();
+    Pop();
   });
 }


### PR DESCRIPTION
The add tests were not keeping correctly maintaining the stack state. They were leaving the return value on the stack.